### PR TITLE
Refactor case utils

### DIFF
--- a/packages/twenty-server/src/utils/camel-case.ts
+++ b/packages/twenty-server/src/utils/camel-case.ts
@@ -1,27 +1,9 @@
-import isObject from 'lodash.isobject';
 import lodashCamelCase from 'lodash.camelcase';
 import { CamelCase, CamelCasedPropertiesDeep } from 'type-fest';
+import { transformCaseDeep } from 'src/utils/transform-case-deep';
 
 export const camelCase = <T>(text: T) =>
   lodashCamelCase(text as unknown as string) as CamelCase<T>;
 
-export const camelCaseDeep = <T>(value: T): CamelCasedPropertiesDeep<T> => {
-  // Check if it's an array
-  if (Array.isArray(value)) {
-    return value.map(camelCaseDeep) as CamelCasedPropertiesDeep<T>;
-  }
-
-  // Check if it's an object
-  if (isObject(value)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: Record<string, any> = {};
-
-    for (const key in value) {
-      result[camelCase(key)] = camelCaseDeep(value[key]);
-    }
-
-    return result as CamelCasedPropertiesDeep<T>;
-  }
-
-  return value as CamelCasedPropertiesDeep<T>;
-};
+export const camelCaseDeep = <T>(value: T): CamelCasedPropertiesDeep<T> =>
+  transformCaseDeep<T, CamelCasedPropertiesDeep<T>>(value, camelCase);

--- a/packages/twenty-server/src/utils/kebab-case.ts
+++ b/packages/twenty-server/src/utils/kebab-case.ts
@@ -1,27 +1,9 @@
-import isObject from 'lodash.isobject';
 import lodashKebabCase from 'lodash.kebabcase';
 import { KebabCase, KebabCasedPropertiesDeep } from 'type-fest';
+import { transformCaseDeep } from 'src/utils/transform-case-deep';
 
 export const kebabCase = <T>(text: T) =>
   lodashKebabCase(text as unknown as string) as KebabCase<T>;
 
-export const kebabCaseDeep = <T>(value: T): KebabCasedPropertiesDeep<T> => {
-  // Check if it's an array
-  if (Array.isArray(value)) {
-    return value.map(kebabCaseDeep) as KebabCasedPropertiesDeep<T>;
-  }
-
-  // Check if it's an object
-  if (isObject(value)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: Record<string, any> = {};
-
-    for (const key in value) {
-      result[kebabCase(key)] = kebabCaseDeep(value[key]);
-    }
-
-    return result as KebabCasedPropertiesDeep<T>;
-  }
-
-  return value as KebabCasedPropertiesDeep<T>;
-};
+export const kebabCaseDeep = <T>(value: T): KebabCasedPropertiesDeep<T> =>
+  transformCaseDeep<T, KebabCasedPropertiesDeep<T>>(value, kebabCase);

--- a/packages/twenty-server/src/utils/pascal-case.ts
+++ b/packages/twenty-server/src/utils/pascal-case.ts
@@ -1,28 +1,10 @@
-import isObject from 'lodash.isobject';
 import lodashCamelCase from 'lodash.camelcase';
 import upperFirst from 'lodash.upperfirst';
 import { PascalCase, PascalCasedPropertiesDeep } from 'type-fest';
+import { transformCaseDeep } from 'src/utils/transform-case-deep';
 
 export const pascalCase = <T>(text: T) =>
   upperFirst(lodashCamelCase(text as unknown as string)) as PascalCase<T>;
 
-export const pascalCaseDeep = <T>(value: T): PascalCasedPropertiesDeep<T> => {
-  // Check if it's an array
-  if (Array.isArray(value)) {
-    return value.map(pascalCaseDeep) as PascalCasedPropertiesDeep<T>;
-  }
-
-  // Check if it's an object
-  if (isObject(value)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: Record<string, any> = {};
-
-    for (const key in value) {
-      result[pascalCase(key)] = pascalCaseDeep(value[key]);
-    }
-
-    return result as PascalCasedPropertiesDeep<T>;
-  }
-
-  return value as PascalCasedPropertiesDeep<T>;
-};
+export const pascalCaseDeep = <T>(value: T): PascalCasedPropertiesDeep<T> =>
+  transformCaseDeep<T, PascalCasedPropertiesDeep<T>>(value, pascalCase);

--- a/packages/twenty-server/src/utils/snake-case.ts
+++ b/packages/twenty-server/src/utils/snake-case.ts
@@ -1,27 +1,9 @@
-import isObject from 'lodash.isobject';
 import lodashSnakeCase from 'lodash.snakecase';
 import { SnakeCase, SnakeCasedPropertiesDeep } from 'type-fest';
+import { transformCaseDeep } from 'src/utils/transform-case-deep';
 
 export const snakeCase = <T>(text: T) =>
   lodashSnakeCase(text as unknown as string) as SnakeCase<T>;
 
-export const snakeCaseDeep = <T>(value: T): SnakeCasedPropertiesDeep<T> => {
-  // Check if it's an array
-  if (Array.isArray(value)) {
-    return value.map(snakeCaseDeep) as SnakeCasedPropertiesDeep<T>;
-  }
-
-  // Check if it's an object
-  if (isObject(value)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: Record<string, any> = {};
-
-    for (const key in value) {
-      result[snakeCase(key)] = snakeCaseDeep(value[key]);
-    }
-
-    return result as SnakeCasedPropertiesDeep<T>;
-  }
-
-  return value as SnakeCasedPropertiesDeep<T>;
-};
+export const snakeCaseDeep = <T>(value: T): SnakeCasedPropertiesDeep<T> =>
+  transformCaseDeep<T, SnakeCasedPropertiesDeep<T>>(value, snakeCase);

--- a/packages/twenty-server/src/utils/transform-case-deep.ts
+++ b/packages/twenty-server/src/utils/transform-case-deep.ts
@@ -1,0 +1,17 @@
+import isObject from 'lodash.isobject';
+
+export const transformCaseDeep = <T, R>(value: T, caseFn: (text: string) => string): R => {
+  if (Array.isArray(value)) {
+    return value.map((item) => transformCaseDeep(item, caseFn)) as unknown as R;
+  }
+
+  if (isObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const key in value) {
+      result[caseFn(key)] = transformCaseDeep((value as Record<string, unknown>)[key], caseFn);
+    }
+    return result as unknown as R;
+  }
+
+  return value as unknown as R;
+};


### PR DESCRIPTION
## Summary
- reduce code duplication in server utilities by introducing `transformCaseDeep`
- use new helper in camel-case, snake-case, kebab-case, and pascal-case utilities

## Testing
- `yarn nx run twenty-server:test` *(fails: connect EHOSTUNREACH)*